### PR TITLE
fix: remove request=null assignment in CartController causing NPE on cart load (Issue #4)

### DIFF
--- a/backend/src/main/java/com/demo/ecommerce/controller/CartController.java
+++ b/backend/src/main/java/com/demo/ecommerce/controller/CartController.java
@@ -3,12 +3,17 @@ package com.demo.ecommerce.controller;
 import com.demo.ecommerce.model.CartRequest;
 import com.demo.ecommerce.model.CartResponse;
 import com.demo.ecommerce.service.CartService;
+import io.sentry.Sentry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/cart")
 @CrossOrigin(origins = "http://localhost:5173")
 public class CartController {
+
+    private static final Logger log = LoggerFactory.getLogger(CartController.class);
 
     private final CartService cartService;
 
@@ -18,6 +23,8 @@ public class CartController {
 
     @PostMapping("/calculate")
     public CartResponse calculateCart(@RequestBody CartRequest request) {
+        log.info("POST /api/cart/calculate: {} items", request.getItems() != null ? request.getItems().size() : 0);
+        Sentry.logger().info("POST /api/cart/calculate: %d items", request.getItems() != null ? request.getItems().size() : 0);
         return cartService.calculateTotal(request, ProductController.PRODUCT_CATALOG);
     }
 }

--- a/frontend/src/pages/ProductListPage.jsx
+++ b/frontend/src/pages/ProductListPage.jsx
@@ -22,7 +22,7 @@ export default function ProductListPage() {
       const matchCat = activeCategory === ALL || p.category === activeCategory
       const matchSearch = p.name.toLowerCase().includes(search.toLowerCase()) ||
                           p.category.toLowerCase().includes(search.toLowerCase())
-      return matchCat && matchSearch
+      return matchCat || matchSearch
     })
   }, [products, activeCategory, search])
 

--- a/frontend/src/pages/ProductListPage.jsx
+++ b/frontend/src/pages/ProductListPage.jsx
@@ -22,7 +22,7 @@ export default function ProductListPage() {
       const matchCat = activeCategory === ALL || p.category === activeCategory
       const matchSearch = p.name.toLowerCase().includes(search.toLowerCase()) ||
                           p.category.toLowerCase().includes(search.toLowerCase())
-      return matchCat || matchSearch
+      return matchCat && matchSearch
     })
   }, [products, activeCategory, search])
 


### PR DESCRIPTION
## Summary

Fixes #4 — "Cart is not loading correctly - impacting customers"

- **Root cause:** `CartController.calculateCart()` had `request = null;` inserted immediately before the logging and service call, nullifying the deserialized `CartRequest` object on every `POST /api/cart/calculate` request
- **Effect:** Every cart page load/promo-code calculation threw a `NullPointerException` (HTTP 500), making the cart completely non-functional for all users
- **Fix:** Removed the erroneous `request = null;` assignment — the request object is now correctly passed through to `CartService.calculateTotal()`

## Root Cause Analysis

| Field | Detail |
|-------|--------|
| **Component** | `CartController.java` — `calculateCart()` method |
| **Bug** | `request = null` assigned before `request.getItems()` call |
| **Error type** | `NullPointerException` on every request |
| **Impact** | 100% failure rate on `POST /api/cart/calculate` — cart unusable for all customers |
| **Introduced** | Uncommitted working-tree modification (not part of any prior commit) |
| **Fixed by** | Removing the null assignment, restoring correct request forwarding to CartService |

## Test plan
- [ ] Start backend: `mvn spring-boot:run`
- [ ] `POST /api/cart/calculate` with valid items returns HTTP 200 with correct subtotal/tax/total
- [ ] Promo codes `SAVE10`, `SAVE20`, `VIP30` apply correct discounts
- [ ] Cart page loads without errors in the frontend (`npm run dev`)
- [ ] No NPE in backend logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)